### PR TITLE
fix: refactor `WarframestatWebsocket` for websocket usuage

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -31,4 +31,8 @@ Future<void> main() async {
   final profile = await profileClient.fetchProfile();
 
   print(profile.username);
+
+  final ws = WarframestatWebsocket();
+
+  ws.worldstate().listen((data) => print(data.timestamp));
 }

--- a/lib/src/clients/worldstate_client.dart
+++ b/lib/src/clients/worldstate_client.dart
@@ -3,7 +3,6 @@ import 'dart:isolate';
 
 import 'package:meta/meta.dart';
 import 'package:warframestat_client/warframestat_client.dart';
-import 'package:web_socket_client/web_socket_client.dart';
 
 /// {@template warframestat_client}
 /// Exposes all endpoints pertaining to worldstate.
@@ -11,23 +10,6 @@ import 'package:web_socket_client/web_socket_client.dart';
 class WorldstateClient extends WarframestatClient {
   /// {@macro warframestat_client}
   WorldstateClient({super.language, super.ua, super.client});
-
-  /// Opens a websocket connection for worldstate updates.
-  @Deprecated('User WarframestatWebsocket instead')
-  Stream<Worldstate> worldstateWebSocket([WebSocket? webSocket]) {
-    final ws = Uri.parse('wss://api.warframestat.us/socket');
-    final socket = webSocket ??
-        WebSocket(ws, pingInterval: const Duration(milliseconds: 30000));
-
-    return socket.messages
-        .map((event) => json.decode(event as String) as Map<String, dynamic>)
-        .where((event) => event['event'] == 'ws:update')
-        .map((event) => event['packet'] as Map<String, dynamic>)
-        .where((event) => event['language'] == language.name)
-        .map(
-          (event) => Worldstate.fromJson(event['data'] as Map<String, dynamic>),
-        );
-  }
 
   /// Retrives a fully translated [Worldstate].
   Future<Worldstate> fetchWorldstate() async {

--- a/lib/src/models/worldstate/worldstate.dart
+++ b/lib/src/models/worldstate/worldstate.dart
@@ -149,6 +149,7 @@ class Worldstate extends Equatable {
 
   @override
   List<Object?> get props => [
+        timestamp,
         alerts,
         arbitration,
         weeklyChallenges,

--- a/lib/src/models/worldstate/worldstate_object.dart
+++ b/lib/src/models/worldstate/worldstate_object.dart
@@ -26,5 +26,5 @@ abstract class WorldstateObject extends Equatable {
   Duration? get remaining => expiry?.toLocal().difference(DateTime.now());
 
   @override
-  List<Object?> get props => [id];
+  List<Object?> get props => [id, activation, expiry];
 }

--- a/lib/src/websocket/warframestat.dart
+++ b/lib/src/websocket/warframestat.dart
@@ -3,25 +3,27 @@ import 'dart:convert';
 import 'package:warframestat_client/warframestat_client.dart';
 import 'package:web_socket_client/web_socket_client.dart';
 
+const _pingInterval = Duration(milliseconds: 25000);
 final _baseUrl = Uri.parse('wss://api.warframestat.us/socket');
+
+/// Warframestat websocket event types
+enum WarframestatEvents {
+  /// Worldstate update
+  update('ws:update');
+
+  const WarframestatEvents(this.raw);
+
+  /// Event string
+  final String raw;
+}
 
 /// {@template warframestat_websocket}
 /// Subscribes to warframestat's websock.
 /// {@endtemplate}
 class WarframestatWebsocket {
   /// {@macro warframestat_websocket}
-  WarframestatWebsocket(WebSocket websocket, this.language)
-      : _websocket = websocket;
-
-  /// Creates a static websocket instance.
-  factory WarframestatWebsocket.connect({Language language = Language.en}) {
-    final socket = WebSocket(
-      _baseUrl,
-      pingInterval: const Duration(milliseconds: 25000),
-    );
-
-    return WarframestatWebsocket(socket, language);
-  }
+  WarframestatWebsocket([this.language = Language.en])
+      : _websocket = WebSocket(_baseUrl, pingInterval: _pingInterval);
 
   /// The language code to filter by
   final Language language;
@@ -29,17 +31,17 @@ class WarframestatWebsocket {
   final WebSocket _websocket;
 
   /// A stream of worldstate events
-  Stream<Worldstate> worldstateEvents() {
-    const eventName = 'ws:update';
+  Stream<Worldstate> worldstate() {
+    return packets(WarframestatEvents.update)
+        .where((e) => e['language'] == language.name)
+        .map((e) => Worldstate.fromJson(e['data'] as Map<String, dynamic>));
+  }
 
-    Worldstate toState(Map<String, dynamic> event) =>
-        Worldstate.fromJson(event['data'] as Map<String, dynamic>);
-
+  /// Complete stream of websocket events filterd down to the packets themselves
+  Stream<Map<String, dynamic>> packets(WarframestatEvents event) {
     return _websocket.messages
-        .map((event) => json.decode(event as String) as Map<String, dynamic>)
-        .where((event) => event['event'] == eventName)
-        .map((event) => event['packet'] as Map<String, dynamic>)
-        .where((event) => event['language'] == language.name)
-        .map(toState);
+        .map((e) => json.decode(e as String) as Map<String, dynamic>)
+        .where((e) => e['event'] == event.raw)
+        .map((e) => e['packet'] as Map<String, dynamic>);
   }
 }

--- a/lib/src/websocket/warframestat.dart
+++ b/lib/src/websocket/warframestat.dart
@@ -34,7 +34,13 @@ class WarframestatWebsocket {
   Stream<Worldstate> worldstate() {
     return packets(WarframestatEvents.update)
         .where((e) => e['language'] == language.name)
-        .map((e) => Worldstate.fromJson(e['data'] as Map<String, dynamic>));
+        .map((e) {
+      try {
+        return Worldstate.fromJson(e['data'] as Map<String, dynamic>);
+      } on Exception catch (e, stack) {
+        throw FormatException('Failed to parse worldstate: $e\n$stack');
+      }
+    });
   }
 
   /// Complete stream of websocket events filterd down to the packets themselves

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,4 +23,4 @@ dev_dependencies:
   mocktail: ^1.0.4
   path: ^1.8.3
   test: ^1.25.9
-  very_good_analysis: ">=6.0.0 <8.0.0"
+  very_good_analysis: ^7.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/WFCD
 repository: https://github.com/WFCD/warframestat_client
 
 environment:
-  sdk: ">=3.5.0 <4.0.0"
+  sdk: ^3.6.0
 
 dependencies:
   collection: ">=1.17.0 <2.0.0"


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

* Bump Dart SDK constraints to 3.6.0
* fix: remove worldstateWebSocket from WorldstateClient
* Refactor `WarframestatWebsocket`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added WebSocket functionality for real-time Warframe worldstate updates.
	- Introduced new WebSocket event handling for worldstate data.

- **Improvements**
	- Enhanced object equality comparisons for Worldstate and WorldstateObject.
	- Standardized WebSocket connection setup.

- **Chores**
	- Updated Dart SDK version to 3.6.0.
	- Updated `very_good_analysis` dependency to version 7.0.0.

- **Refactor**
	- Removed deprecated WebSocket method.
	- Renamed and optimized WebSocket event methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->